### PR TITLE
Add workaround for Travis CI environment issue.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - chmod +x /tmp/urchin/package/urchin
   - '[ -z "$WITHOUT_CURL" ] || sudo apt-get remove curl -y'
 script:
+  - export PATH=$(echo $PATH | sed 's/::/:/')
   - NVM_DIR=$TRAVIS_BUILD_DIR make TEST_SUITE=$TEST_SUITE URCHIN=/tmp/urchin/package/urchin test-$SHELL
 env:
   - SHELL=bash TEST_SUITE=install_script


### PR DESCRIPTION
This adds a workaround for an issue that's causing the install_script tests to fail on Travis CI's new Ubuntu Precise environment.

There are double colon sections in the `$PATH` environment variable that cause commands like `type` to look in the current working directory. As the scripts in `test/install_script` are named the same as the functions that are being used, this causes confusion and the tests to fail.
