### PR TITLE
Add || true to .bashrc lines in case set -e is on

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -325,8 +325,8 @@ nvm_do_install() {
   local PROFILE_INSTALL_DIR
   PROFILE_INSTALL_DIR="$(nvm_install_dir| sed "s:^$HOME:\$HOME:")"
 
-  SOURCE_STR="\nexport NVM_DIR=\"${PROFILE_INSTALL_DIR}\"\n[ -s \"\$NVM_DIR/nvm.sh\" ] && \\. \"\$NVM_DIR/nvm.sh\"  # This loads nvm\n"
-  COMPLETION_STR="[ -s \"\$NVM_DIR/bash_completion\" ] && \\. \"\$NVM_DIR/bash_completion\"  # This loads nvm bash_completion\n"
+  SOURCE_STR="\nexport NVM_DIR=\"${PROFILE_INSTALL_DIR}\"\n[ -s \"\$NVM_DIR/nvm.sh\" ] && \\. \"\$NVM_DIR/nvm.sh\" || true # This loads nvm\n"
+  COMPLETION_STR="[ -s \"\$NVM_DIR/bash_completion\" ] && \\. \"\$NVM_DIR/bash_completion\" || true # This loads nvm bash_completion\n"
   BASH_OR_ZSH=false
 
   if [ -z "${NVM_PROFILE-}" ] ; then


### PR DESCRIPTION
In the (super-rare) case that someone does something like:

```bash
set -e
. ~/.bashrc
```

**_and_** the nvm lines are the last two lines in the shell script, **_and_** the nvm directory doesn't exist, the bashrc will return 1 as the exit code, killing the parent shell.

To be honest I'm not sure it's worth fixing this edge case, most people who aren't writing scripts don't have `set -e` in their shell, and most people writing shell scripts aren't sourcing their 

An alternative workaround for this is to add `; true` (or `; :` for maximum opacity) instead of `|| true`), but I feel like `|| true` is most obvious.

I tested this by doing:

```bash
▶▶▶ SOURCE_STR="\nexport NVM_DIR=\"${PROFILE_INSTALL_DIR}\"\n[ -s \"\$NVM_DIR/nvm.sh\" ] && \\. \"\$NVM_DIR/nvm.sh\" || true  # This loads nvm\n"
COMPLETION_STR="[ -s \"\$NVM_DIR/bash_completion\" ] && \\. \"\$NVM_DIR/bash_completion\" || true # This loads nvm bash_completion\n"
▶▶▶ printf "${COMPLETION_STR}"
[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" || true # This loads nvm bash_completion
▶▶▶ printf "${SOURCE_STR}"

export NVM_DIR=""
[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" || true  # This loads nvm
```

and it seems to work, I should probably test it more though.

Refs: https://github.com/nodejs/build/issues/988